### PR TITLE
Feature/tdg dg

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "start-local": "run-script-os",
     "start-local:win32": "SET NODE_ENV=local&& node index.js",
     "start-local:darwin:linux": "export NODE_ENV=local; node index.js",
+    "start-standalone": "run-script-os",
+    "start-standalone:win32": "SET NODE_ENV=local&& node standalone.js",
+    "start-standalone:darwin:linux": "export NODE_ENV=local; node standalone.js",
     "lint": "standardx",
     "lint-fix": "standardx --fix"
   },

--- a/settings/local.env
+++ b/settings/local.env
@@ -1,1 +1,1 @@
-ADMIN_BASE_API_URL=http://localhost:9111
+ADMIN_BASE_API_URL=http://localhost:9114

--- a/standalone.js
+++ b/standalone.js
@@ -1,0 +1,3 @@
+const { generate } = require('./index')
+
+generate('standalone', '98f24950-cb26-48c9-9389-7ccb89a576b7')

--- a/test-data/standalone.json
+++ b/test-data/standalone.json
@@ -1,0 +1,83 @@
+{
+    "actions": [
+        {
+            "action": "create",
+            "type": "ManufacturerRecord",
+            "label": "vp1",
+            "data": {
+                "Name": "Raptors and Reptiles-${namespace}",
+                "OrganisationReference": "10347-${namespace}",
+                "Address" : {
+                    "Address": "221B Baker St",
+                    "Address1": "Marylebone",
+                    "Town": "London",
+                    "PostCode": "NW1 6XE",
+                    "Country": "UK"
+                }
+            }
+        },
+        {
+            "action": "create",
+            "type": "ExternalUserRecord",
+            "label": "vet1",
+            "data": {
+                "FirstName": "Sherlock",
+                "LastName": "Holmes",
+                "Email": "{usergen}"
+            }
+        },
+        {
+            "action": "create",
+            "type": "ExternalUserRecord",
+            "label": "vet2",
+            "data": {
+                "FirstName": "John",
+                "LastName": "Watson",
+                "Email": "{usergen}"
+            }
+        },
+        {
+            "action": "create",
+            "type": "ExternalUserRecord",
+            "label": "vet3",
+            "data": {
+                "FirstName": "Molly",
+                "LastName": "Hooper",
+                "Email": "{usergen}"
+            }
+        },
+        {
+            "action": "create",
+            "type": "ExternalUserRecord",
+            "label": "vet4",
+            "testUser": "true",
+            "data": {
+                "FirstName": "Test",
+                "LastName": "User",
+                "Email": "{usergen}"
+            }
+        },
+        {
+            "action": "assignRole",
+            "type": "PrimaryAdminRole",
+            "label": "role3",
+            "data": {
+                "orgId": "vp1",
+                "users": [
+                    "vet4"
+                ]
+            }
+        },
+        {
+            "action": "assignRole",
+            "type": "AdminRole",
+            "label": "role4",
+            "data": {
+                "orgId": "vp1",
+                "users": [
+                    "vet4"
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Ticket
https://vmddefra.atlassian.net/browse/APT-317

## Overview: 
Updated the test data generator so it can be ran in 'standalone' mode.

## Reason: 
The TDG is currently only used to create data for e2e tests, this is the first part in the process of updating it to work for local development data generation too.

## Work carried out:

- [x] added test data folder
- [x] updated local.env to point to the test-support-api
- [x] added 'start-standalone' script
- [x] added standalone.js

## Practical usage example
`npm run start-standalone` (with the test support API running with the `develop` profile (not yet available)

Developer Notes:
- Requires https://github.com/VMDDTE/foundations/pull/803 to be merged before it will work correctly