### PR TITLE
Implement global user capability

### DIFF
--- a/action-processor/assign-role-action.js
+++ b/action-processor/assign-role-action.js
@@ -34,8 +34,9 @@ async function createRole (namespace, action) {
     let orgId = response.Id
 
     var userList = []
+    let userNameSpace = action.global == 'true' ? 'global' : namespace
     for (const userLabel of users) {
-        let savedAction = await localStorage.getItem(namespace, userLabel)
+        let savedAction = await localStorage.getItem(userNameSpace, userLabel)
         let response = savedAction.response
         let userId = response.Id
         log.info(`${SERVICE_NAME}::createRole::assigning role ${roleType} to ${userId} for organisation with id ${orgId}`)

--- a/action-processor/create-action.js
+++ b/action-processor/create-action.js
@@ -491,6 +491,10 @@ async function createExternalUser (featureName, action) {
 async function createSecureMessage (featureName, action){
     log.info(`${SERVICE_NAME}::createSecureMessage::${action.label}::creating a new secure message ${JSON.stringify(action.data)}`)
     let savedUser = await localStorage.getItem(featureName, action.data.FromUser)
+    if (!savedUser) {
+        // Check for a global user
+        savedUser = await localStorage.getItem('global', action.data.FromUser)
+    }
     let response = savedUser.response
     
     let createDraftResponse = await messageService.createDraft(response.Id)

--- a/action-processor/create-action.js
+++ b/action-processor/create-action.js
@@ -553,6 +553,10 @@ async function createSecureMessage (featureName, action){
 async function createSentMessage (featureName, action){
     log.info(`${SERVICE_NAME}::createSentMessage::${action.label}::creating a new sent message ${JSON.stringify(action.data)}`)
     let storedUser = await localStorage.getItem(featureName, action.data.FromUser)
+    if (!storedUser) {
+        // Check for a global user
+        storedUser = await localStorage.getItem('global', action.data.FromUser)
+    }
     let fromUser = storedUser.response
     
     var sentDataPayload = {}
@@ -566,6 +570,12 @@ async function createSentMessage (featureName, action){
         if(savedAction && savedAction.response) {
             log.info(`${SERVICE_NAME}::createSentMessage::RecipientId ${savedAction.response.Id}`)
             sentDataPayload.RecipientIds.push(savedAction.response.Id)
+        } else {
+            let globalUserSavedAction = await localStorage.getItem('global', userLabel)
+            if(globalUserSavedAction && globalUserSavedAction.response) {
+                log.info(`${SERVICE_NAME}::createSentMessage::RecipientId ${globalUserSavedAction.response.Id}`)
+                sentDataPayload.RecipientIds.push(globalUserSavedAction.response.Id)
+            }
         }
     }
 
@@ -611,6 +621,10 @@ function storeMessageIdForDeletion(featureName, messageId){
 async function createStorageRecord (featureName, action){
     log.debug(`${SERVICE_NAME}::createStorage`)
     let savedUser = await localStorage.getItem(featureName, action.data.UserLabel)
+    if (!savedUser) {
+        // Check for a global user
+        savedUser = await localStorage.getItem('global', action.data.UserLabel)
+    }
     let user = savedUser.response
 
     let responseData = await storageService.createStorageRecord(

--- a/action-processor/send-invite-action.js
+++ b/action-processor/send-invite-action.js
@@ -35,9 +35,9 @@ async function sendInvitation (namespace, action) {
     var userList = []
     for (const userLabel of users) {
         let savedAction = await localStorage.getItem(namespace, userLabel)
-        if (!savedUser) {
+        if (!savedAction) {
             // Check for a global user
-            savedUser = await localStorage.getItem('global', userLabel)
+            savedAction = await localStorage.getItem('global', userLabel)
         }
         let response = savedAction.response
         let userId = response.Id

--- a/action-processor/send-invite-action.js
+++ b/action-processor/send-invite-action.js
@@ -35,6 +35,10 @@ async function sendInvitation (namespace, action) {
     var userList = []
     for (const userLabel of users) {
         let savedAction = await localStorage.getItem(namespace, userLabel)
+        if (!savedUser) {
+            // Check for a global user
+            savedUser = await localStorage.getItem('global', userLabel)
+        }
         let response = savedAction.response
         let userId = response.Id
         userList.push(userId)

--- a/controller/generate-controller.js
+++ b/controller/generate-controller.js
@@ -40,6 +40,12 @@ async function tearDown (featureName) {
     await tearDownLocalStorage(featureName)
 }
 
+async function tearDownGlobal () {
+    log.info(`Tearing down ... GLOBAL`)
+    await tearDownEntities('global')
+    await tearDownLocalStorage('global')
+}
+
 async function processActions (featureName, actionJson) {
     let actionRecords = actionJson.actions
 
@@ -315,3 +321,4 @@ async function tearDownDraftMarketingAuthorisationApplication (featureName) {
 
 module.exports.generate = generate
 module.exports.tearDown = tearDown
+module.exports.tearDownGlobal = tearDownGlobal

--- a/index.js
+++ b/index.js
@@ -27,6 +27,10 @@ async function clearAll () {
     localStorage.clearAll()
 }
 
+async function tearDownGlobal () {
+    await generator.tearDownGlobal()
+}
+
 async function getTestUser (filename, namespace) {
     var featureName = filename
     if (namespace) {
@@ -36,6 +40,13 @@ async function getTestUser (filename, namespace) {
     if (testuser) {
         console.log(`Running with Test User [${testuser.Email}] ...`)
         return testuser
+    }
+
+    // Check for a global test user
+    let globalTestUser = localStorage.getItem('global', 'testuser')
+    if (globalTestUser) {
+        console.log(`Running with GLOBAL Test User [${globalTestUser.Email}] ...`)
+        return globalTestUser
     }
     return null
 }
@@ -59,3 +70,4 @@ module.exports.tearDown = tearDown
 module.exports.clearAll = clearAll
 module.exports.getInvites = getInvites
 module.exports.getTestUser = getTestUser
+module.exports.tearDownGlobal = tearDownGlobal


### PR DESCRIPTION
## Ticket
[SIS-5041 Switch MMB to run with a single test user](https://vmddefra.atlassian.net/browse/SIS-5041)

## Overview: 
Run the MMB tests with a single logged in test user and don't keep creating a new user in AD

## Work carried out:

Added the capability to specify a user as `global`, avoiding the need to keep (re) creating.

## Developer Notes:

The concept of the global user can be extended into other areas e.g. have a look at the assign role function. 